### PR TITLE
Add derives for Key

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -233,7 +233,7 @@ impl<ID> Drop for GlobalHotkeySet<ID> {
 }
 
 /// Non-modifier key usable for hotkeys.
-#[derive(IntoPrimitive, Copy, Clone, Eq, PartialEq)]
+#[derive(IntoPrimitive, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 #[repr(i32)]
 pub enum Key {
     Backspace = VK_BACK,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -233,7 +233,7 @@ impl<ID> Drop for GlobalHotkeySet<ID> {
 }
 
 /// Non-modifier key usable for hotkeys.
-#[derive(IntoPrimitive, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
+#[derive(IntoPrimitive, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[repr(i32)]
 pub enum Key {
     Backspace = VK_BACK,

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -90,7 +90,6 @@ use winapi::um::winuser::{
 };
 
 use crate::internal::ReturnValue;
-use winapi::_core::time::Duration;
 
 #[derive(Copy, Clone)]
 struct HotkeyDef<ID> {
@@ -157,11 +156,7 @@ where
         self
     }
 
-    pub fn listen_for_hotkeys(self) -> io::Result<impl IntoIterator<Item = io::Result<ID>>> {
-        self.listen_for_hotkeys_with_sleeptime(None)
-    }
-
-    pub fn listen_for_hotkeys_with_sleeptime(mut self, sleep_time: Option<Duration>) -> io::Result<impl IntoIterator<Item = io::Result<ID>>> {
+    pub fn listen_for_hotkeys(mut self) -> io::Result<impl IntoIterator<Item = io::Result<ID>>> {
         let (tx_hotkey, rx_hotkey) = mpsc::channel();
         thread::spawn(move || {
             let ids = || Self::MIN_ID..;
@@ -196,9 +191,6 @@ where
                     .zip(self.hotkey_defs.iter().map(|def| def.user_id))
                     .collect();
                 loop {
-                    if let Some(sleep) = sleep_time {
-                        std::thread::sleep(sleep);
-                    };
                     let mut message: MaybeUninit<winuser::MSG> = MaybeUninit::uninit();
                     let getmsg_result = unsafe {
                         GetMessageW(message.as_mut_ptr(), ptr::null_mut(), WM_HOTKEY, WM_HOTKEY)


### PR DESCRIPTION
This PR derives trait impls for Ord, PartialOrd and Debug for `Key` to enable using it as key in BTreeMaps.
Additionally the function `listen_for_hotkeys()` can now be optionally called with a Duration to sleep in the polling loop to reduce CPU utilization (not an expert here, but I think the loop implements a busy waiting and sleeping some time will reduce power consumption)